### PR TITLE
Fixes #43

### DIFF
--- a/src/WallpaperChangeScheduler.cs
+++ b/src/WallpaperChangeScheduler.cs
@@ -65,7 +65,8 @@ namespace WinDynamicDesktop
 
             TimeSpan interval = new TimeSpan(tickInterval);
 
-            wallpaperTimer.Interval = (int)interval.TotalMilliseconds;
+            int integerInterval = (int)interval.TotalMilliseconds;
+            wallpaperTimer.Interval = integerInterval <= 0 ? 1 : integerInterval;
             wallpaperTimer.Start();
         }
 


### PR DESCRIPTION
wallpapertimer was being set to 0 in edge cases when integer casting was rounding down.
Makes the timer bottom out at 1 if it's <= 0

Happy to re-evaluate the fix if there's a valid reason the timer should be < 1 and a different solution can be implemented.