### PR TITLE
Fix ArgumentOutOfRangeException when using UWP location

### DIFF
--- a/src/SunriseSunset.cs
+++ b/src/SunriseSunset.cs
@@ -16,7 +16,7 @@ namespace WinDynamicDesktop
 
     class SunriseSunsetService
     {
-        private static CultureInfo cultureInfo = CultureInfo.GetCultureInfo("en-US");
+		private static CultureInfo cultureInfo = CultureInfo.CurrentCulture;
 
         public static WeatherData GetWeatherData(string lat, string lon, string dateStr)
         {


### PR DESCRIPTION
Inside SunriseSunset data for latitude and longitude was parsed using always "en-US" CultureInfo. This was causing ArgumentOutOfRangeException on non English/USA systems. Now the correct CultureInfo is retrieved at runtime with the CurrentCulture property.