### PR TITLE
Added system theme switching

### DIFF
--- a/src/SystemThemeChanger.cs
+++ b/src/SystemThemeChanger.cs
@@ -49,10 +49,12 @@ namespace WinDynamicDesktop
             if (darkTheme)
             {
                 themeKey.SetValue("AppsUseLightTheme", 0);  // Dark theme
+                themeKey.SetValue("SystemUsesLightTheme", 0); // Dark system theme
             }
             else
             {
                 themeKey.SetValue("AppsUseLightTheme", 1);  // Light theme
+                themeKey.SetValue("SystemUsesLightTheme", 1); // Light system theme
             }
 
             themeKey.Close();


### PR DESCRIPTION
Supported in Windows builds >=18282
Should not break in older Windows builds, but will produce registry keys not yet used by the OS