### PR TITLE
Seperate automatic dark app & settings theme (PR for #159)

### DIFF
--- a/src/JsonConfig.cs
+++ b/src/JsonConfig.cs
@@ -1,4 +1,4 @@
-﻿// This Source Code Form is subject to the terms of the Mozilla Public
+// This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
@@ -26,6 +26,7 @@ namespace WinDynamicDesktop
         public bool disableAutoUpdate { get; set; }
         public string lastUpdateCheck { get; set; }
         public bool changeSystemTheme { get; set; }
+        public bool changeAppTheme { get; set; }
         public string themeName { get; set; }
         public bool useWindowsLocation { get; set; }
         public bool changeLockScreen { get; set; }

--- a/src/MainMenu.cs
+++ b/src/MainMenu.cs
@@ -45,7 +45,7 @@ namespace WinDynamicDesktop
             });
             items[0].Enabled = false;
 
-            darkModeItem = new ToolStripMenuItem(_("Enable &Dark Mode"), null, OnDarkModeClick);
+            darkModeItem = new ToolStripMenuItem(_("&Night wallpaper only mode"), null, OnDarkModeClick);
             darkModeItem.Checked = JsonConfig.settings.darkMode;
             startOnBootItem = new ToolStripMenuItem(_("&Start on Boot"), null, OnStartOnBootClick);
 
@@ -74,7 +74,6 @@ namespace WinDynamicDesktop
             List<ToolStripItem> items = new List<ToolStripItem>();
 
             items.Add(new ToolStripMenuItem(_("Select &Language..."), null, OnLanguageItemClick));
-            items.Add(new ToolStripSeparator());
             items.AddRange(SystemThemeChanger.GetMenuItems());
             items.AddRange(UpdateChecker.GetMenuItems());
 

--- a/src/SystemThemeChanger.cs
+++ b/src/SystemThemeChanger.cs
@@ -17,60 +17,94 @@ namespace WinDynamicDesktop
         private const string registryThemeLocation =
             @"Software\Microsoft\Windows\CurrentVersion\Themes\Personalize";
 
-        private static ToolStripMenuItem menuItem;
+        private static ToolStripMenuItem automaticSystemThemeItem;
+        private static ToolStripMenuItem automaticAppThemeItem;
 
         public static List<ToolStripItem> GetMenuItems()
         {
             RegistryKey themeKey = Registry.CurrentUser.OpenSubKey(registryThemeLocation);
 
-            if (!UwpDesktop.IsRunningAsUwp() && (themeKey != null))
-            {
-                themeKey.Close();
-
-                menuItem = new ToolStripMenuItem(
-                    Localization.GetTranslation("&Change Windows 10 theme color"),
-                    null, OnThemeItemClick);
-                menuItem.Checked = JsonConfig.settings.changeSystemTheme;
-
-                return new List<ToolStripItem>() { menuItem };
-            }
-            else
+            if (UwpDesktop.IsRunningAsUwp() || themeKey == null)
             {
                 JsonConfig.settings.changeSystemTheme = false;
+                JsonConfig.settings.changeAppTheme = false;
 
                 return new List<ToolStripItem>();
             }
+
+            themeKey.Close();
+
+            automaticSystemThemeItem = new ToolStripMenuItem(
+                Localization.GetTranslation("Change Windows 10 &system theme automatically"),
+                null, OnSystemThemeItemClick);
+            automaticSystemThemeItem.Checked = JsonConfig.settings.changeSystemTheme;
+
+            automaticAppThemeItem = new ToolStripMenuItem(
+                Localization.GetTranslation("Change Windows 10 &app theme automatically"),
+                null, OnAppThemeItemClick);
+            automaticAppThemeItem.Checked = JsonConfig.settings.changeSystemTheme;
+
+            return new List<ToolStripItem>() {
+                new ToolStripSeparator(),
+                automaticSystemThemeItem,
+                automaticAppThemeItem
+            };
         }
 
         public static void TryUpdateSystemTheme()
         {
-            if (!JsonConfig.settings.changeSystemTheme)
+            bool changeSystemTheme = JsonConfig.settings.changeSystemTheme;
+            bool changeAppTheme = JsonConfig.settings.changeAppTheme;
+
+            if (!changeSystemTheme && !changeAppTheme)
             {
                 return;
             }
 
-            bool darkTheme = !WallpaperChangeScheduler.isSunUp || JsonConfig.settings.darkMode;
+            bool isNight = !WallpaperChangeScheduler.isSunUp;
             RegistryKey themeKey = Registry.CurrentUser.OpenSubKey(registryThemeLocation, true);
 
-            if (darkTheme)
+            if (changeSystemTheme)
             {
-                themeKey.SetValue("AppsUseLightTheme", 0);      // Dark app theme
-                themeKey.SetValue("SystemUsesLightTheme", 0);   // Dark system theme
+                if (isNight)
+                {
+                    themeKey.SetValue("SystemUsesLightTheme", 0);   // Dark system theme
+                }
+                else
+                {
+                    themeKey.SetValue("SystemUsesLightTheme", 1);   // Light system theme
+                }
             }
-            else
+
+            if (changeAppTheme)
             {
-                themeKey.SetValue("AppsUseLightTheme", 1);      // Light app theme
-                themeKey.SetValue("SystemUsesLightTheme", 1);   // Light system theme
+                if (isNight)
+                {
+                    themeKey.SetValue("AppsUseLightTheme", 0);      // Dark app theme
+                }
+                else
+                {
+                    themeKey.SetValue("AppsUseLightTheme", 1);      // Light app theme
+                }
             }
 
             themeKey.Close();
         }
 
-        private static void OnThemeItemClick(object sender, EventArgs e)
+        private static void OnSystemThemeItemClick(object sender, EventArgs e)
         {
             bool isEnabled = JsonConfig.settings.changeSystemTheme ^ true;
             JsonConfig.settings.changeSystemTheme = isEnabled;
-            menuItem.Checked = isEnabled;
+            automaticSystemThemeItem.Checked = isEnabled;
+
+            TryUpdateSystemTheme();
+        }
+
+        private static void OnAppThemeItemClick(object sender, EventArgs e)
+        {
+            bool isEnabled = JsonConfig.settings.changeAppTheme ^ true;
+            JsonConfig.settings.changeAppTheme = isEnabled;
+            automaticAppThemeItem.Checked = isEnabled;
 
             TryUpdateSystemTheme();
         }

--- a/src/UpdateChecker.cs
+++ b/src/UpdateChecker.cs
@@ -58,7 +58,10 @@ namespace WinDynamicDesktop
                     null, OnAutoUpdateItemClick);
                 menuItem.Checked = !JsonConfig.settings.disableAutoUpdate;
 
-                return new List<ToolStripItem>() { menuItem };
+                return new List<ToolStripItem>() {
+                    new ToolStripSeparator(),
+                    menuItem
+                };
             }
             else
             {


### PR DESCRIPTION
This commit changes the following:
- Rename "Enable Dark Mode" to "Night wallpaper only mode" for clarity.
- Remove the forced dark mode from "Enable Dark Mode". You can change this in Windows if you want it to always be dark. The option is currently a bit confusing for UWP users that think it changes the system theme.
- Add a separate toggle for automatic system theme and automatic app theme changes. They do what they say on the tin.
- (Minor UI) Move the toolstrip seperator to the GetMenuItems methods to clean up the UI for UWP users, where previously a lingering seperator was visible at the bottom of "More Options".

Please let me know if you want me to change anything. I've tested everything in this PR and everything is working as intended. The only concern I have with it is the removal of the forced dark mode. If what I did is not favorable, let me know and I'll revert it.