### PR TITLE
Fix crash on corrupt settings.conf file

### DIFF
--- a/src/JsonConfig.cs
+++ b/src/JsonConfig.cs
@@ -9,8 +9,7 @@ using System.Threading.Tasks;
 using System.ComponentModel;
 using System.IO;
 using Newtonsoft.Json;
-using System.Windows.Forms;
-using Timer = System.Timers.Timer;
+using System.Timers;
 
 namespace WinDynamicDesktop
 {
@@ -72,7 +71,9 @@ namespace WinDynamicDesktop
                 }
                 catch (JsonReaderException)
                 {
-                    MessageBox.Show("Your configuration file was corrupt and has been reset to the default settings.");
+                    System.Windows.Forms.MessageBox.Show("Your WinDynamicDesktop configuration file was corrupt and has been reset to the default settings.", "Warning",
+                    System.Windows.Forms.MessageBoxButtons.OK,
+                    System.Windows.Forms.MessageBoxIcon.Warning);
                     firstRun = true;
                 }
             }

--- a/src/JsonConfig.cs
+++ b/src/JsonConfig.cs
@@ -3,14 +3,14 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 using System;
-using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using System.ComponentModel;
 using System.IO;
-using System.Timers;
 using Newtonsoft.Json;
+using System.Windows.Forms;
+using Timer = System.Timers.Timer;
 
 namespace WinDynamicDesktop
 {
@@ -65,8 +65,16 @@ namespace WinDynamicDesktop
 
             if (!firstRun)
             {
-                string jsonText = File.ReadAllText("settings.conf");
-                settings = JsonConvert.DeserializeObject<AppConfig>(jsonText);
+                try
+                {
+                    string jsonText = File.ReadAllText("settings.conf");
+                    settings = JsonConvert.DeserializeObject<AppConfig>(jsonText);
+                }
+                catch (JsonReaderException)
+                {
+                    MessageBox.Show("Your configuration file was corrupt and has been reset to the default settings.");
+                    firstRun = true;
+                }
             }
 
             unsavedChanges = false;


### PR DESCRIPTION
As per issue #144, this fixes the program crashing when the settings.conf file got corrupted somehow. It simply notifies the user of this and then proceeds as if it's the first-time run. In theory more could be done to recover available config data, but honestly it's not worth it.