### PR TITLE
Hide the "Use Windows location services" when not on UWP

### DIFF
--- a/src/LocationDialog.cs
+++ b/src/LocationDialog.cs
@@ -45,7 +45,7 @@ namespace WinDynamicDesktop
             }
 
             locationCheckBox.Checked = JsonConfig.settings.useWindowsLocation;
-            locationCheckBox.Enabled = UwpDesktop.IsRunningAsUwp();
+            locationCheckBox.Visible = UwpDesktop.IsRunningAsUwp();
 
             UpdateGuiState();
             locationCheckBox.CheckedChanged += locationCheckBox_CheckedChanged;


### PR DESCRIPTION
As per issue #130, people are getting confused as to why the Windows location services is not available to be clicked when not on UWP. Instead of causing unnecessary confusion with this, hide the checkbox altogether while not on UWP.