### PR TITLE
Add wallpaper compression disable/enable option

### DIFF
--- a/src/MainMenu.cs
+++ b/src/MainMenu.cs
@@ -76,6 +76,7 @@ namespace WinDynamicDesktop
             items.Add(new ToolStripMenuItem(_("Select &Language..."), null, OnLanguageItemClick));
             items.Add(new ToolStripSeparator());
             items.AddRange(SystemThemeChanger.GetMenuItems());
+            items.AddRange(WallpaperCompressionChanger.GetMenuItems());
             items.AddRange(UpdateChecker.GetMenuItems());
 
             return items;

--- a/src/WallpaperCompressionChanger.cs
+++ b/src/WallpaperCompressionChanger.cs
@@ -16,6 +16,7 @@ namespace WinDynamicDesktop
     {
         private const string registryCompressionLocation = @"Control Panel\Desktop";
 
+        private static readonly Func<string, string> _ = Localization.GetTranslation;
         private static ToolStripMenuItem compressionTweakItem;
         private static bool isWallpaperCompressionTweaked;
 
@@ -33,7 +34,7 @@ namespace WinDynamicDesktop
             desktopKey.Close();
 
             compressionTweakItem = new ToolStripMenuItem(
-                Localization.GetTranslation("Disable Windows 10 &JPEG wallpaper compression"),
+                _("Disable Windows 10 &JPEG wallpaper compression"),
                 null, OnWallpaperCompressionItemClick);
             compressionTweakItem.Checked = isWallpaperCompressionTweaked;
 
@@ -67,7 +68,11 @@ namespace WinDynamicDesktop
         {
             TryApplyWallpaperCompressionTweak();
             compressionTweakItem.Checked = isWallpaperCompressionTweaked;
-            MessageBox.Show(Localization.GetTranslation("This tweak only affects wallpapers that are JPEG images. In order for this change to take effect, you should restart your computer."));
+            MessageBox.Show(
+                _("This tweak only affects wallpapers that are JPEG images. In order for this change to take effect, you should restart your computer."),
+                _("WinDynamicDesktop"),
+                MessageBoxButtons.OK,
+                MessageBoxIcon.Information);
         }
     }
 }

--- a/src/WallpaperCompressionChanger.cs
+++ b/src/WallpaperCompressionChanger.cs
@@ -1,0 +1,72 @@
+﻿// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows.Forms;
+using Microsoft.Win32;
+
+namespace WinDynamicDesktop
+{
+    class WallpaperCompressionChanger
+    {
+        private const string registryCompressionLocation = @"Control Panel\Desktop";
+
+        private static ToolStripMenuItem compressionTweakItem;
+        private static bool isWallpaperCompressionTweaked;
+
+        public static List<ToolStripItem> GetMenuItems()
+        {
+            RegistryKey desktopKey = Registry.CurrentUser.OpenSubKey(registryCompressionLocation);
+
+            if (UwpDesktop.IsRunningAsUwp() || desktopKey == null)
+            {
+                return new List<ToolStripItem>();
+            }
+
+            isWallpaperCompressionTweaked = (int)desktopKey.GetValue("JPEGImportQuality", 0) == 100;
+
+            desktopKey.Close();
+
+            compressionTweakItem = new ToolStripMenuItem(
+                Localization.GetTranslation("Disable Windows 10 &JPEG wallpaper compression"),
+                null, OnWallpaperCompressionItemClick);
+            compressionTweakItem.Checked = isWallpaperCompressionTweaked;
+
+            return new List<ToolStripItem>() {
+                new ToolStripSeparator(),
+                compressionTweakItem,
+            };
+        }
+
+        public static void TryApplyWallpaperCompressionTweak()
+        {
+            RegistryKey desktopKey = Registry.CurrentUser.OpenSubKey(registryCompressionLocation, true);
+
+            if (isWallpaperCompressionTweaked)
+            {
+                // Disable the wallpaper compression tweak.
+                desktopKey.DeleteValue("JPEGImportQuality");
+            }
+            else
+            {
+                // Enable the wallpaper compression tweak.
+                desktopKey.SetValue("JPEGImportQuality", 100);
+            }
+
+            isWallpaperCompressionTweaked = (int)desktopKey.GetValue("JPEGImportQuality", 0) == 100;
+
+            desktopKey.Close();
+        }
+
+        private static void OnWallpaperCompressionItemClick(object sender, EventArgs e)
+        {
+            TryApplyWallpaperCompressionTweak();
+            compressionTweakItem.Checked = isWallpaperCompressionTweaked;
+        }
+    }
+}

--- a/src/WallpaperCompressionChanger.cs
+++ b/src/WallpaperCompressionChanger.cs
@@ -67,6 +67,7 @@ namespace WinDynamicDesktop
         {
             TryApplyWallpaperCompressionTweak();
             compressionTweakItem.Checked = isWallpaperCompressionTweaked;
+            MessageBox.Show(Localization.GetTranslation("This tweak only affects wallpapers that are JPEG images. In order for this change to take effect, you should restart your computer."));
         }
     }
 }

--- a/src/WinDynamicDesktop.csproj
+++ b/src/WinDynamicDesktop.csproj
@@ -163,6 +163,7 @@
     <Compile Include="UwpLocation.cs" />
     <Compile Include="WallpaperApi.cs" />
     <Compile Include="WallpaperChangeScheduler.cs" />
+    <Compile Include="WallpaperCompressionChanger.cs" />
     <EmbeddedResource Include="AboutDialog.resx">
       <DependentUpon>AboutDialog.cs</DependentUpon>
     </EmbeddedResource>


### PR DESCRIPTION
As per issue #148, this implements a simple registry tweak to enable or disable compression of JPEG image wallpapers on Windows 10. Follows the same basic logic as SystemThemeChange, but bases the current checked state off the current registry key value so there's no need for an additional config option. This tweak is based off [this WindowsCentral article](https://www.windowscentral.com/how-disable-image-compression-desktop-wallpapers-windows-10), and may require a system reboot in order to take effect.