### PR TITLE
Added basic image interpolation

### DIFF
--- a/src/Interpolation.cs
+++ b/src/Interpolation.cs
@@ -1,0 +1,81 @@
+﻿using System;
+
+namespace WinDynamicDesktop
+{
+    public enum InterpolationMethod
+    {
+        None,
+        Linear,
+        Quad,
+        Cubic,
+        Quart,
+        Quint,
+        Sine,
+        Circle,
+        Exponential
+    }
+
+    public static class Interpolation
+    {
+        public static float Calculate(float value, InterpolationMethod method)
+        {
+            if (value < 0)
+            {
+                return 0;
+            }
+            else if (value > 1)
+            {
+                return 1;
+            }
+
+            switch (method)
+            {
+                default:
+                case InterpolationMethod.None:
+                    return 0;
+
+                case InterpolationMethod.Linear:
+                    return value;
+
+                case InterpolationMethod.Quad:
+                    return InOut(value, Quad);
+
+                case InterpolationMethod.Cubic:
+                    return InOut(value, Cubic);
+
+                case InterpolationMethod.Quart:
+                    return InOut(value, Quart);
+
+                case InterpolationMethod.Quint:
+                    return InOut(value, Quint);
+
+                case InterpolationMethod.Sine:
+                    return InOut(value, Sine);
+
+                case InterpolationMethod.Circle:
+                    return InOut(value, Circle);
+
+                case InterpolationMethod.Exponential:
+                    return InOut(value, Exponential);
+            }
+        }
+
+        private static float InOut(float value, Func<float,float> func)
+        {
+            if (value >= 0.5f)
+            {
+                return (1 - func((1 - value) * 2)) / 2 + 0.5f;
+
+            }
+            return func(value * 2) / 2;
+        }
+
+        private static float Quad(float value) => (float)Math.Pow(value, 2);
+        private static float Cubic(float value) => (float)Math.Pow(value, 3);
+        private static float Quart(float value) => (float)Math.Pow(value, 4);
+        private static float Quint(float value) => (float)Math.Pow(value, 5);
+        private static float Exponential(float value) => ((float)Math.Exp(2 * value) - 1) / ((float)Math.Exp(2) - 1);
+        private static float Sine(float value) => 1 - (float)Math.Sin(Math.PI / 2 * (1 - value));
+        private static float Circle(float value) => 1 - (float)Math.Sqrt(1.0 - value * value);
+    }
+}

--- a/src/JsonConfig.cs
+++ b/src/JsonConfig.cs
@@ -41,6 +41,7 @@ namespace WinDynamicDesktop
         public int sunriseSunsetDuration { get; set; }
         public bool fullScreenPause { get; set; }
         public bool enableScripts { get; set; }
+        public bool enableInterpolation { get; set; }
     }
 
     class JsonConfig

--- a/src/MainMenu.cs
+++ b/src/MainMenu.cs
@@ -18,6 +18,7 @@ namespace WinDynamicDesktop
         public static ToolStripMenuItem themeItem;
         public static ToolStripMenuItem darkModeItem;
         public static ToolStripMenuItem startOnBootItem;
+        public static ToolStripMenuItem interpolateItem;
         public static ToolStripMenuItem enableScriptsItem;
         public static ToolStripMenuItem shuffleItem;
         public static ToolStripMenuItem fullScreenItem;
@@ -99,6 +100,11 @@ namespace WinDynamicDesktop
             enableScriptsItem.Checked = JsonConfig.settings.enableScripts;
             items.Add(enableScriptsItem);
             items.Add(new ToolStripMenuItem(_("Manage installed scripts"), null, OnManageScriptsClick));
+            items.Add(new ToolStripSeparator());
+
+            interpolateItem = new ToolStripMenuItem(_("&Enable image interpolation"), null, OnEnableInterpolationClick);
+            interpolateItem.Checked = JsonConfig.settings.enableInterpolation;
+            items.Add(interpolateItem);
 
             return items;
         }
@@ -176,6 +182,11 @@ namespace WinDynamicDesktop
         private static void OnManageScriptsClick(object sender, EventArgs e)
         {
             Process.Start("explorer", "scripts");
+        }
+
+        private static void OnEnableInterpolationClick(object sender, EventArgs e)
+        {
+            AppContext.wpEngine.ToggleInterpolation();
         }
     }
 }

--- a/src/SunriseSunset.cs
+++ b/src/SunriseSunset.cs
@@ -26,11 +26,11 @@ namespace WinDynamicDesktop
     {
         private static readonly Func<string, string> _ = Localization.GetTranslation;
 
-        private static SolarData GetUserProvidedSolarData()
+        private static SolarData GetUserProvidedSolarData(DateTime date)
         {
             SolarData data = new SolarData();
-            data.sunriseTime = UpdateHandler.SafeParse(JsonConfig.settings.sunriseTime);
-            data.sunsetTime = UpdateHandler.SafeParse(JsonConfig.settings.sunsetTime);
+            data.sunriseTime = date.Date + UpdateHandler.SafeParse(JsonConfig.settings.sunriseTime).TimeOfDay;
+            data.sunsetTime = date.Date + UpdateHandler.SafeParse(JsonConfig.settings.sunsetTime).TimeOfDay;
 
             int halfSunriseSunsetDuration = JsonConfig.settings.sunriseSunsetDuration * 30;
             data.solarTimes = new DateTime[4]
@@ -58,7 +58,7 @@ namespace WinDynamicDesktop
         {
             if (JsonConfig.settings.dontUseLocation)
             {
-                return GetUserProvidedSolarData();
+                return GetUserProvidedSolarData(date);
             }
 
             double latitude = double.Parse(JsonConfig.settings.latitude, CultureInfo.InvariantCulture);

--- a/src/ThemeLoader.cs
+++ b/src/ThemeLoader.cs
@@ -11,6 +11,7 @@ using System.IO;
 using System.IO.Compression;
 using System.Windows.Forms;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
 
 namespace WinDynamicDesktop
 {
@@ -20,6 +21,8 @@ namespace WinDynamicDesktop
         public string displayName { get; set; }
         public string imageFilename { get; set; }
         public string imageCredits { get; set; }
+        [JsonConverter(typeof(StringEnumConverter))]
+        public InterpolationMethod interpolation { get; set; }
         public int? dayHighlight { get; set; }
         public int? nightHighlight { get; set; }
         public int[] sunriseImageList { get; set; }

--- a/src/ThemePreviewer.cs
+++ b/src/ThemePreviewer.cs
@@ -32,7 +32,7 @@ namespace WinDynamicDesktop
                 replacers.Add("previewMessage", string.Format(_("Previewing {0}"), "<span id=\"previewText\"></span>"));
 
                 SolarData solarData = SunriseSunsetService.GetSolarData(DateTime.Today);
-                SchedulerState wpState = AppContext.wpEngine.GetImageData(solarData, theme);
+                SchedulerState wpState = AppContext.wpEngine.GetImageData(solarData, theme, DateTime.Now);
 
                 if (ThemeManager.IsThemeDownloaded(theme))
                 {

--- a/src/WinDynamicDesktop.csproj
+++ b/src/WinDynamicDesktop.csproj
@@ -76,6 +76,7 @@
       <DependentUpon>AboutDialog.cs</DependentUpon>
     </Compile>
     <Compile Include="AppContext.cs" />
+    <Compile Include="Interpolation.cs" />
     <Compile Include="HttpEnvironmentProxy.cs" />
     <Compile Include="IpcManager.cs" />
     <Compile Include="ProxyWrapper.cs" />


### PR DESCRIPTION
This feature creates a smooth transition over time for each image in a theme.
It can be set per theme by specifying an 'interpolation', and be enabled/disabled globally via the 'enableInterpolation' setting.

For now at least, the interpolated images are encoded as JPEGs. When working with very high resolution images, I had issues getting BMP or PNG to work properly. My guess is they take too long to save, and the scheduler is trying to open them before they're actually done (the result is completely black). This can probably be solved later.

This also fixes a bug where calling `SunriseSunsetService.GetSolarData` while location is disabled could return a date in the past, causing the scheduler to run repeatedly.

Let me know if you have any questions.