### PR TITLE
Add experimental multi-monitor wallpaper sync across virtual desktops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Enhancements
 
 * Added Tahoe Abstract and Golden Gate Abstract themes
+* Added experimental multi-monitor wallpaper sync across virtual desktops, including an XZ Desktop Wallpaper ByPass state bridge
 * Updated to .NET 10 which enables dark mode across entire application ([#553](https://github.com/t1m0thyj/WinDynamicDesktop/issues/553))
 * Rewrote theme preview renderer to be more lightweight by using Skia framework ([#672](https://github.com/t1m0thyj/WinDynamicDesktop/pull/672))
 * Added Lithuanian translation (thanks Matas)

--- a/README.md
+++ b/README.md
@@ -30,6 +30,14 @@ Choose a schedule for cycling through wallpaper images over 24 hours
 
 Extend the behavior of WinDynamicDesktop with PowerShell scripts, and share them with other users [here](https://github.com/t1m0thyj/WDD-scripts#readme)
 
+## Virtual Desktops
+
+On Windows 11 22H2 and newer, the experimental **Sync multi-monitor wallpaper across virtual desktops**
+option under **More Options** can keep a multi-monitor theme consistent when switching virtual desktops. It
+combines each monitor's selected image using the physical display layout reported by Windows, then applies the
+result as a spanned wallpaper to every virtual desktop. The option is disabled by default and only applies when
+different themes are configured per display.
+
 ## Supported Devices
 
 WinDynamicDesktop is developed primarily for Windows 11, but should run on any device with Windows 7 or newer. Windows Insider builds are not officially supported.

--- a/README.md
+++ b/README.md
@@ -38,6 +38,10 @@ combines each monitor's selected image using the physical display layout reporte
 result as a spanned wallpaper to every virtual desktop. The option is disabled by default and only applies when
 different themes are configured per display.
 
+After a successful sync, this fork writes `%LOCALAPPDATA%\XZWallpaperBypass\WDD-Span\state.json` so
+[XZ Desktop Wallpaper ByPass](https://github.com/David-Lzy/XZ_Desktop_wallpaper_ByPass) can reload the
+same composite without asking WDD to refresh again.
+
 ## Supported Devices
 
 WinDynamicDesktop is developed primarily for Windows 11, but should run on any device with Windows 7 or newer. Windows Insider builds are not officially supported.

--- a/src/COM/VirtualDesktopWallpaper.cs
+++ b/src/COM/VirtualDesktopWallpaper.cs
@@ -1,0 +1,162 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+using System;
+using System.Runtime.InteropServices;
+
+namespace WinDynamicDesktop.COM
+{
+    // Internal interface layout reference:
+    // https://github.com/MScholtes/PSVirtualDesktop/blob/master/VirtualDesktop.ps1
+    internal static class VirtualDesktopWallpaperApi
+    {
+        private static readonly Guid CLSID_ImmersiveShell =
+            new Guid("C2F03A33-21F5-47FA-B4BB-156362A2F239");
+        private static readonly Guid CLSID_VirtualDesktopManagerInternal =
+            new Guid("C5E0CDCA-7B6E-41B2-9FC4-D93975CC467B");
+
+        internal static bool IsSupported => OperatingSystem.IsWindowsVersionAtLeast(10, 0, 22621);
+
+        internal static bool TrySetWallpaperForAllDesktops(string imagePath)
+        {
+            if (!IsSupported)
+            {
+                return false;
+            }
+
+            object shell = null;
+            object manager = null;
+            try
+            {
+                Type shellType = Type.GetTypeFromCLSID(CLSID_ImmersiveShell, true);
+                shell = Activator.CreateInstance(shellType);
+                IServiceProvider serviceProvider = (IServiceProvider)shell;
+                Guid service = CLSID_VirtualDesktopManagerInternal;
+                Guid interfaceId = typeof(IVirtualDesktopManagerInternal22621).GUID;
+                manager = serviceProvider.QueryService(ref service, ref interfaceId);
+
+                using HString path = HString.Create(imagePath);
+                if (Environment.OSVersion.Version.Build >= 26100)
+                {
+                    ((IVirtualDesktopManagerInternal26100)manager)
+                        .UpdateWallpaperPathForAllDesktops(path);
+                }
+                else
+                {
+                    ((IVirtualDesktopManagerInternal22621)manager)
+                        .UpdateWallpaperPathForAllDesktops(path);
+                }
+
+                return true;
+            }
+            catch (Exception exc)
+            {
+                LoggingHandler.LogMessage("Could not update wallpaper for all virtual desktops: {0}",
+                    exc.ToString());
+                LoggingHandler.LogError(exc);
+                return false;
+            }
+            finally
+            {
+                if (manager != null && Marshal.IsComObject(manager))
+                {
+                    Marshal.ReleaseComObject(manager);
+                }
+                if (shell != null && Marshal.IsComObject(shell))
+                {
+                    Marshal.ReleaseComObject(shell);
+                }
+            }
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        internal readonly struct HString : IDisposable
+        {
+            private readonly IntPtr value;
+
+            private HString(IntPtr value)
+            {
+                this.value = value;
+            }
+
+            internal static HString Create(string value)
+            {
+                Marshal.ThrowExceptionForHR(WindowsCreateString(value, value.Length, out IntPtr handle));
+                return new HString(handle);
+            }
+
+            public void Dispose()
+            {
+                if (value != IntPtr.Zero)
+                {
+                    WindowsDeleteString(value);
+                }
+            }
+
+            [DllImport("combase.dll", CallingConvention = CallingConvention.StdCall)]
+            private static extern int WindowsCreateString([MarshalAs(UnmanagedType.LPWStr)] string sourceString,
+                int length, out IntPtr hstring);
+
+            [DllImport("combase.dll", CallingConvention = CallingConvention.StdCall)]
+            private static extern int WindowsDeleteString(IntPtr hstring);
+        }
+
+        [ComImport]
+        [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+        [Guid("6D5140C1-7436-11CE-8034-00AA006009FA")]
+        private interface IServiceProvider
+        {
+            [return: MarshalAs(UnmanagedType.IUnknown)]
+            object QueryService(ref Guid service, ref Guid interfaceId);
+        }
+
+        // This private Windows interface changes between feature updates. Only the final method is invoked;
+        // placeholders document and preserve the vtable slot used on Windows 11 22H2 and 23H2.
+        [ComImport]
+        [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+        [Guid("53F5CA0B-158F-4124-900C-057158060B27")]
+        private interface IVirtualDesktopManagerInternal22621
+        {
+            void Slot00();
+            void Slot01();
+            void Slot02();
+            void Slot03();
+            void Slot04();
+            void Slot05();
+            void Slot06();
+            void Slot07();
+            void Slot08();
+            void Slot09();
+            void Slot10();
+            void Slot11();
+            void Slot12();
+            void Slot13();
+            void UpdateWallpaperPathForAllDesktops(HString path);
+        }
+
+        // Windows 11 24H2 added SwitchDesktopAndMoveForegroundView at slot 7.
+        [ComImport]
+        [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+        [Guid("53F5CA0B-158F-4124-900C-057158060B27")]
+        private interface IVirtualDesktopManagerInternal26100
+        {
+            void Slot00();
+            void Slot01();
+            void Slot02();
+            void Slot03();
+            void Slot04();
+            void Slot05();
+            void Slot06();
+            void Slot07();
+            void Slot08();
+            void Slot09();
+            void Slot10();
+            void Slot11();
+            void Slot12();
+            void Slot13();
+            void Slot14();
+            void UpdateWallpaperPathForAllDesktops(HString path);
+        }
+    }
+}

--- a/src/EventScheduler.cs
+++ b/src/EventScheduler.cs
@@ -1,4 +1,4 @@
-﻿// This Source Code Form is subject to the terms of the Mozilla Public
+// This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
@@ -114,13 +114,17 @@ namespace WinDynamicDesktop
                 }
             }
 
+            string[] imagePaths = displayEvents.Select(e =>
+                (e.displayIndex == overrideEvent?.displayIndex ? overrideEvent : e).lastImagePath).ToArray();
+            SpannedWallpaperManager.Update(imagePaths.Take(displayEvents.Count - 1).ToArray(),
+                JsonConfig.settings.activeThemes[0] == null && overrideEvent == null);
+
             ScriptManager.RunScripts(new ScriptArgs
             {
                 daySegment2 = displayEvents[0].daySegment2,
                 daySegment4 = displayEvents[0].daySegment4 ?? -1,
                 themeMode = JsonConfig.settings.appearanceMode,
-                imagePaths = displayEvents.Select(e =>
-                    (e.displayIndex == overrideEvent?.displayIndex ? overrideEvent : e).lastImagePath).ToArray()
+                imagePaths = imagePaths
             }, forceImageUpdate);
 
             nextUpdateTime = SolarScheduler.CalcNextUpdateTime(data);
@@ -264,7 +268,7 @@ namespace WinDynamicDesktop
 
         private void OnDisplaySettingsChanged(object sender, EventArgs e)
         {
-            if (UpdateDisplayList())
+            if (UpdateDisplayList() || JsonConfig.settings.syncVirtualDesktopWallpapers)
             {
                 LoggingHandler.LogMessage("Scheduler event triggered by display change");
                 HandleTimerEvent(false);
@@ -274,6 +278,7 @@ namespace WinDynamicDesktop
         private void OnPowerModeChanged(object sender, PowerModeChangedEventArgs e)
         {
             if (e.Mode == PowerModes.Resume && (UpdateDisplayList() ||
+                JsonConfig.settings.syncVirtualDesktopWallpapers ||
                 (nextUpdateTime.HasValue && DateTime.Now >= nextUpdateTime.Value)))
             {
                 LoggingHandler.LogMessage("Scheduler event triggered by resume from sleep");
@@ -284,6 +289,7 @@ namespace WinDynamicDesktop
         private void OnSessionSwitch(object sender, SessionSwitchEventArgs e)
         {
             if (e.Reason == SessionSwitchReason.SessionUnlock && (UpdateDisplayList() ||
+                JsonConfig.settings.syncVirtualDesktopWallpapers ||
                 (nextUpdateTime.HasValue && DateTime.Now >= nextUpdateTime.Value)))
             {
                 LoggingHandler.LogMessage("Scheduler event triggered by user session unlock");

--- a/src/JsonConfig.cs
+++ b/src/JsonConfig.cs
@@ -49,6 +49,8 @@ namespace WinDynamicDesktop
         [Notify] private bool _fullScreenPause { get; set; }
         [Notify] private bool _enableScripts { get; set; }
         [Notify] private bool _debugLogging { get; set; }
+        [Notify] private bool _syncVirtualDesktopWallpapers { get; set; }
+        [Notify] private int _wallpaperPositionBeforeVirtualDesktopSync { get; set; } = -1;
     }
 
     class JsonConfig

--- a/src/SpannedWallpaperManager.cs
+++ b/src/SpannedWallpaperManager.cs
@@ -1,0 +1,229 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+using SkiaSharp;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices;
+using WinDynamicDesktop.COM;
+
+namespace WinDynamicDesktop
+{
+    internal static class SpannedWallpaperManager
+    {
+        private static readonly IntPtr DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2 = new IntPtr(-4);
+        private static readonly string cacheDirectory =
+            Path.Combine(Path.GetFullPath("cache"), "virtual-desktop-wallpaper");
+        private static readonly object wallpaperLock = new object();
+
+        [DllImport("user32.dll")]
+        private static extern IntPtr SetThreadDpiAwarenessContext(IntPtr dpiContext);
+
+        internal static void Update(IReadOnlyList<string> imagePaths, bool usePerDisplayThemes)
+        {
+            lock (wallpaperLock)
+            {
+                UpdateCore(imagePaths, usePerDisplayThemes);
+            }
+        }
+
+        private static void UpdateCore(IReadOnlyList<string> imagePaths, bool usePerDisplayThemes)
+        {
+            if (!CanApply(imagePaths, usePerDisplayThemes))
+            {
+                RestoreWallpaperPosition();
+                return;
+            }
+
+            if (!imagePaths.All(path => !string.IsNullOrEmpty(path) && File.Exists(path)))
+            {
+                LoggingHandler.LogMessage("Skipping virtual desktop wallpaper sync because an image is missing");
+                RestoreWallpaperPosition();
+                return;
+            }
+
+            Apply(imagePaths);
+        }
+
+        private static bool CanApply(IReadOnlyList<string> imagePaths, bool usePerDisplayThemes)
+        {
+            return JsonConfig.settings.syncVirtualDesktopWallpapers && usePerDisplayThemes &&
+                imagePaths != null && imagePaths.Count > 1 && VirtualDesktopWallpaperApi.IsSupported;
+        }
+
+        private static void Apply(IReadOnlyList<string> imagePaths)
+        {
+            IDesktopWallpaper desktopWallpaper = null;
+            List<string> monitorIds = new List<string>();
+            try
+            {
+                desktopWallpaper = DesktopWallpaperFactory.Create();
+                List<WallpaperMonitor> monitors = GetMonitors(desktopWallpaper, imagePaths, monitorIds);
+                DesktopWallpaperPosition sourcePosition = SaveWallpaperPosition(desktopWallpaper);
+                COLORREF color = desktopWallpaper.GetBackgroundColor();
+                string outputPath = SpannedWallpaperRenderer.RenderToCache(monitors, sourcePosition,
+                    new SKColor(color.R, color.G, color.B), cacheDirectory);
+
+                desktopWallpaper.SetPosition(DesktopWallpaperPosition.DWPOS_SPAN);
+                desktopWallpaper.SetWallpaper(null, outputPath);
+                if (!VirtualDesktopWallpaperApi.TrySetWallpaperForAllDesktops(outputPath))
+                {
+                    RestoreCurrentDesktop(desktopWallpaper, monitorIds, imagePaths, sourcePosition);
+                    return;
+                }
+
+                LoggingHandler.LogMessage("Set spanned wallpaper for all virtual desktops: {0}", outputPath);
+                SpannedWallpaperRenderer.CleanCache(cacheDirectory, outputPath);
+            }
+            catch (Exception exc)
+            {
+                LoggingHandler.LogMessage("Error syncing virtual desktop wallpapers: {0}", exc.ToString());
+                LoggingHandler.LogError(exc);
+                RestoreAfterFailure(desktopWallpaper, monitorIds, imagePaths);
+            }
+            finally
+            {
+                ReleaseComObject(desktopWallpaper);
+            }
+        }
+
+        private static List<WallpaperMonitor> GetMonitors(IDesktopWallpaper desktopWallpaper,
+            IReadOnlyList<string> imagePaths, List<string> monitorIds)
+        {
+            uint monitorCount = desktopWallpaper.GetMonitorDevicePathCount();
+            if (monitorCount < (uint)imagePaths.Count)
+            {
+                RestoreWallpaperPosition(desktopWallpaper);
+                throw new InvalidOperationException(string.Format("Windows returned {0} monitors but {1} images " +
+                    "are configured", monitorCount, imagePaths.Count));
+            }
+
+            List<WallpaperMonitor> monitors = new List<WallpaperMonitor>();
+            IntPtr previousDpiContext = SetThreadDpiAwarenessContext(
+                DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2);
+            try
+            {
+                for (int i = 0; i < imagePaths.Count; i++)
+                {
+                    string monitorId = desktopWallpaper.GetMonitorDevicePathAt((uint)i);
+                    monitorIds.Add(monitorId);
+                    monitors.Add(new WallpaperMonitor
+                    {
+                        Bounds = desktopWallpaper.GetMonitorRECT(monitorId),
+                        ImagePath = imagePaths[i]
+                    });
+                }
+            }
+            finally
+            {
+                if (previousDpiContext != IntPtr.Zero)
+                {
+                    SetThreadDpiAwarenessContext(previousDpiContext);
+                }
+            }
+
+            return monitors;
+        }
+
+        private static DesktopWallpaperPosition SaveWallpaperPosition(IDesktopWallpaper desktopWallpaper)
+        {
+            DesktopWallpaperPosition currentPosition = desktopWallpaper.GetPosition();
+            if (JsonConfig.settings.wallpaperPositionBeforeVirtualDesktopSync < 0)
+            {
+                JsonConfig.settings.wallpaperPositionBeforeVirtualDesktopSync = (int)currentPosition;
+            }
+
+            return GetSavedPosition();
+        }
+
+        private static void RestoreAfterFailure(IDesktopWallpaper desktopWallpaper,
+            IReadOnlyList<string> monitorIds, IReadOnlyList<string> imagePaths)
+        {
+            if (desktopWallpaper != null && monitorIds.Count == imagePaths.Count)
+            {
+                RestoreCurrentDesktop(desktopWallpaper, monitorIds, imagePaths, GetSavedPosition());
+            }
+            else
+            {
+                RestoreWallpaperPosition(desktopWallpaper);
+            }
+        }
+
+        internal static void RestoreWallpaperPosition()
+        {
+            lock (wallpaperLock)
+            {
+                RestoreWallpaperPosition(null);
+            }
+        }
+
+        private static void RestoreWallpaperPosition(IDesktopWallpaper existingDesktopWallpaper)
+        {
+            if (JsonConfig.settings.wallpaperPositionBeforeVirtualDesktopSync < 0)
+            {
+                return;
+            }
+
+            IDesktopWallpaper desktopWallpaper = existingDesktopWallpaper;
+            try
+            {
+                desktopWallpaper ??= DesktopWallpaperFactory.Create();
+                if (desktopWallpaper.GetPosition() == DesktopWallpaperPosition.DWPOS_SPAN)
+                {
+                    desktopWallpaper.SetPosition(GetSavedPosition());
+                }
+                JsonConfig.settings.wallpaperPositionBeforeVirtualDesktopSync = -1;
+            }
+            catch (Exception exc)
+            {
+                LoggingHandler.LogMessage("Could not restore wallpaper position: {0}", exc.ToString());
+                LoggingHandler.LogError(exc);
+            }
+            finally
+            {
+                if (existingDesktopWallpaper == null && desktopWallpaper != null &&
+                    Marshal.IsComObject(desktopWallpaper))
+                {
+                    Marshal.ReleaseComObject(desktopWallpaper);
+                }
+            }
+        }
+
+        private static void RestoreCurrentDesktop(IDesktopWallpaper desktopWallpaper,
+            IReadOnlyList<string> monitorIds, IReadOnlyList<string> imagePaths,
+            DesktopWallpaperPosition position)
+        {
+            try
+            {
+                desktopWallpaper.SetPosition(position);
+                for (int i = 0; i < monitorIds.Count; i++)
+                {
+                    desktopWallpaper.SetWallpaper(monitorIds[i], imagePaths[i]);
+                }
+            }
+            catch (Exception exc)
+            {
+                LoggingHandler.LogMessage("Could not restore per-monitor wallpapers: {0}", exc.ToString());
+                LoggingHandler.LogError(exc);
+            }
+        }
+
+        private static void ReleaseComObject(object value)
+        {
+            if (value != null && Marshal.IsComObject(value))
+            {
+                Marshal.ReleaseComObject(value);
+            }
+        }
+
+        private static DesktopWallpaperPosition GetSavedPosition()
+        {
+            int position = JsonConfig.settings.wallpaperPositionBeforeVirtualDesktopSync;
+            return Enum.IsDefined(typeof(DesktopWallpaperPosition), position) ?
+                (DesktopWallpaperPosition)position : DesktopWallpaperPosition.DWPOS_FILL;
+        }
+    }
+}

--- a/src/SpannedWallpaperManager.cs
+++ b/src/SpannedWallpaperManager.cs
@@ -3,6 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 using SkiaSharp;
+using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -75,6 +76,7 @@ namespace WinDynamicDesktop
                     return;
                 }
 
+                WriteXzWallpaperState(outputPath);
                 LoggingHandler.LogMessage("Set spanned wallpaper for all virtual desktops: {0}", outputPath);
                 SpannedWallpaperRenderer.CleanCache(cacheDirectory, outputPath);
             }
@@ -216,6 +218,23 @@ namespace WinDynamicDesktop
             if (value != null && Marshal.IsComObject(value))
             {
                 Marshal.ReleaseComObject(value);
+            }
+        }
+
+        private static void WriteXzWallpaperState(string outputPath)
+        {
+            try
+            {
+                string directory = Path.Combine(Environment.GetFolderPath(
+                    Environment.SpecialFolder.LocalApplicationData), "XZWallpaperBypass", "WDD-Span");
+                Directory.CreateDirectory(directory);
+                File.WriteAllText(Path.Combine(directory, "state.json"),
+                    JsonConvert.SerializeObject(new { output = outputPath }));
+            }
+            catch (Exception exc)
+            {
+                LoggingHandler.LogMessage("Could not notify XZDesktop of wallpaper update: {0}",
+                    exc.ToString());
             }
         }
 

--- a/src/SpannedWallpaperRenderer.cs
+++ b/src/SpannedWallpaperRenderer.cs
@@ -1,0 +1,185 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+using SkiaSharp;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Security.Cryptography;
+using System.Text;
+using WinDynamicDesktop.COM;
+
+namespace WinDynamicDesktop
+{
+    internal static class SpannedWallpaperRenderer
+    {
+        private static readonly SKSamplingOptions sampling =
+            new SKSamplingOptions(SKFilterMode.Linear, SKMipmapMode.None);
+
+        internal static RECT GetVirtualBounds(IReadOnlyList<WallpaperMonitor> monitors)
+        {
+            if (monitors == null || monitors.Count == 0)
+            {
+                throw new ArgumentException("At least one monitor is required", nameof(monitors));
+            }
+
+            return new RECT
+            {
+                Left = monitors.Min(m => m.Bounds.Left),
+                Top = monitors.Min(m => m.Bounds.Top),
+                Right = monitors.Max(m => m.Bounds.Right),
+                Bottom = monitors.Max(m => m.Bounds.Bottom)
+            };
+        }
+
+        internal static SKBitmap Render(IReadOnlyList<WallpaperMonitor> monitors,
+            DesktopWallpaperPosition position, SKColor backgroundColor)
+        {
+            RECT virtualBounds = GetVirtualBounds(monitors);
+            int width = checked(virtualBounds.Right - virtualBounds.Left);
+            int height = checked(virtualBounds.Bottom - virtualBounds.Top);
+            if (width <= 0 || height <= 0)
+            {
+                throw new ArgumentException("The monitor layout has invalid bounds", nameof(monitors));
+            }
+            if ((width * (long)height) > 100_000_000)
+            {
+                throw new ArgumentException("The monitor layout is too large to render safely", nameof(monitors));
+            }
+
+            SKBitmap output = new SKBitmap(new SKImageInfo(width, height, SKColorType.Bgra8888,
+                SKAlphaType.Opaque));
+            using SKCanvas canvas = new SKCanvas(output);
+            canvas.Clear(backgroundColor);
+
+            foreach (WallpaperMonitor monitor in monitors)
+            {
+                using SKBitmap source = SKBitmap.Decode(monitor.ImagePath) ??
+                    throw new InvalidDataException("Could not decode wallpaper image: " + monitor.ImagePath);
+                SKRect destination = new SKRect(
+                    monitor.Bounds.Left - virtualBounds.Left,
+                    monitor.Bounds.Top - virtualBounds.Top,
+                    monitor.Bounds.Right - virtualBounds.Left,
+                    monitor.Bounds.Bottom - virtualBounds.Top);
+
+                canvas.Save();
+                canvas.ClipRect(destination);
+                DrawImage(canvas, source, destination, position);
+                canvas.Restore();
+            }
+
+            return output;
+        }
+
+        internal static string RenderToCache(IReadOnlyList<WallpaperMonitor> monitors,
+            DesktopWallpaperPosition position, SKColor backgroundColor, string cacheDirectory)
+        {
+            Directory.CreateDirectory(cacheDirectory);
+            string cacheKey = GetCacheKey(monitors, position, backgroundColor);
+            string outputPath = Path.Combine(cacheDirectory, "spanned-" + cacheKey + ".jpg");
+            if (File.Exists(outputPath))
+            {
+                return outputPath;
+            }
+
+            string tempPath = outputPath + ".tmp";
+            using (SKBitmap bitmap = Render(monitors, position, backgroundColor))
+            using (SKImage image = SKImage.FromBitmap(bitmap))
+            using (SKData data = image.Encode(SKEncodedImageFormat.Jpeg, 95))
+            using (FileStream stream = File.Create(tempPath))
+            {
+                data.SaveTo(stream);
+            }
+
+            File.Move(tempPath, outputPath, true);
+            return outputPath;
+        }
+
+        internal static void CleanCache(string cacheDirectory, string currentPath, int filesToKeep = 4)
+        {
+            try
+            {
+                foreach (FileInfo file in new DirectoryInfo(cacheDirectory).EnumerateFiles("spanned-*.jpg")
+                    .OrderByDescending(f => f.LastWriteTimeUtc).Skip(filesToKeep))
+                {
+                    if (!string.Equals(file.FullName, currentPath, StringComparison.OrdinalIgnoreCase))
+                    {
+                        file.Delete();
+                    }
+                }
+            }
+            catch (Exception exc)
+            {
+                LoggingHandler.LogMessage("Could not clean spanned wallpaper cache: {0}", exc.Message);
+            }
+        }
+
+        private static void DrawImage(SKCanvas canvas, SKBitmap source, SKRect monitor,
+            DesktopWallpaperPosition position)
+        {
+            switch (position)
+            {
+                case DesktopWallpaperPosition.DWPOS_CENTER:
+                    float left = monitor.MidX - (source.Width / 2f);
+                    float top = monitor.MidY - (source.Height / 2f);
+                    canvas.DrawBitmap(source, left, top, sampling, null);
+                    break;
+
+                case DesktopWallpaperPosition.DWPOS_TILE:
+                    for (float y = monitor.Top; y < monitor.Bottom; y += source.Height)
+                    {
+                        for (float x = monitor.Left; x < monitor.Right; x += source.Width)
+                        {
+                            canvas.DrawBitmap(source, x, y, sampling, null);
+                        }
+                    }
+                    break;
+
+                case DesktopWallpaperPosition.DWPOS_STRETCH:
+                    canvas.DrawBitmap(source, monitor, sampling, null);
+                    break;
+
+                case DesktopWallpaperPosition.DWPOS_FIT:
+                    DrawScaled(canvas, source, monitor, Math.Min(
+                        monitor.Width / source.Width, monitor.Height / source.Height));
+                    break;
+
+                case DesktopWallpaperPosition.DWPOS_FILL:
+                case DesktopWallpaperPosition.DWPOS_SPAN:
+                default:
+                    DrawScaled(canvas, source, monitor, Math.Max(
+                        monitor.Width / source.Width, monitor.Height / source.Height));
+                    break;
+            }
+        }
+
+        private static void DrawScaled(SKCanvas canvas, SKBitmap source, SKRect monitor, float scale)
+        {
+            float width = source.Width * scale;
+            float height = source.Height * scale;
+            SKRect destination = SKRect.Create(monitor.MidX - (width / 2f), monitor.MidY - (height / 2f),
+                width, height);
+            canvas.DrawBitmap(source, destination, sampling, null);
+        }
+
+        private static string GetCacheKey(IReadOnlyList<WallpaperMonitor> monitors,
+            DesktopWallpaperPosition position, SKColor backgroundColor)
+        {
+            StringBuilder value = new StringBuilder();
+            value.Append((int)position).Append('|').Append(backgroundColor).Append('|');
+            foreach (WallpaperMonitor monitor in monitors)
+            {
+                FileInfo file = new FileInfo(monitor.ImagePath);
+                value.Append(monitor.Bounds.Left).Append(',').Append(monitor.Bounds.Top).Append(',')
+                    .Append(monitor.Bounds.Right).Append(',').Append(monitor.Bounds.Bottom).Append('|')
+                    .Append(file.FullName).Append('|').Append(file.Length).Append('|')
+                    .Append(file.LastWriteTimeUtc.Ticks).Append(';');
+            }
+
+            byte[] digest = SHA256.HashData(Encoding.UTF8.GetBytes(value.ToString()));
+            return Convert.ToHexString(digest)[..16].ToLowerInvariant();
+        }
+    }
+}

--- a/src/TrayMenu.cs
+++ b/src/TrayMenu.cs
@@ -1,4 +1,4 @@
-﻿// This Source Code Form is subject to the terms of the Mozilla Public
+// This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
@@ -18,6 +18,7 @@ namespace WinDynamicDesktop
         public static ToolStripMenuItem fullScreenItem;
         public static ToolStripMenuItem hideTrayItem;
         public static ToolStripMenuItem enableScriptsItem;
+        public static ToolStripMenuItem syncVirtualDesktopWallpapersItem;
 
         public TrayMenu()
         {
@@ -69,10 +70,16 @@ namespace WinDynamicDesktop
             fullScreenItem.Checked = JsonConfig.settings.fullScreenPause;
             hideTrayItem = new ToolStripMenuItem(_("Hide system tray icon"), null, OnHideTrayItemClick);
             hideTrayItem.Checked = JsonConfig.settings.hideTrayIcon;
+            syncVirtualDesktopWallpapersItem = new ToolStripMenuItem(
+                _("Sync multi-monitor wallpaper across virtual desktops (experimental)"), null,
+                OnSyncVirtualDesktopWallpapersClick);
+            syncVirtualDesktopWallpapersItem.Checked = JsonConfig.settings.syncVirtualDesktopWallpapers;
+            syncVirtualDesktopWallpapersItem.Enabled = COM.VirtualDesktopWallpaperApi.IsSupported;
             items.AddRange(new ToolStripItem[]
             {
                 fullScreenItem,
                 hideTrayItem,
+                syncVirtualDesktopWallpapersItem,
                 new ToolStripSeparator()
             });
 
@@ -148,6 +155,20 @@ namespace WinDynamicDesktop
         private void OnHideTrayItemClick(object sender, EventArgs e)
         {
             AppContext.ToggleTrayIcon();
+        }
+
+        private void OnSyncVirtualDesktopWallpapersClick(object sender, EventArgs e)
+        {
+            JsonConfig.settings.syncVirtualDesktopWallpapers =
+                !JsonConfig.settings.syncVirtualDesktopWallpapers;
+            syncVirtualDesktopWallpapersItem.Checked =
+                JsonConfig.settings.syncVirtualDesktopWallpapers;
+
+            if (!JsonConfig.settings.syncVirtualDesktopWallpapers)
+            {
+                SpannedWallpaperManager.RestoreWallpaperPosition();
+            }
+            AppContext.scheduler.Run(true);
         }
 
         private void OnEditConfigFileClick(object sender, EventArgs e)

--- a/src/WallpaperMonitor.cs
+++ b/src/WallpaperMonitor.cs
@@ -1,0 +1,14 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+using WinDynamicDesktop.COM;
+
+namespace WinDynamicDesktop
+{
+    internal class WallpaperMonitor
+    {
+        public RECT Bounds { get; init; }
+        public string ImagePath { get; init; }
+    }
+}

--- a/test/SpannedWallpaperRendererTests.cs
+++ b/test/SpannedWallpaperRendererTests.cs
@@ -1,0 +1,92 @@
+using SkiaSharp;
+using WinDynamicDesktop.COM;
+
+namespace WinDynamicDesktop.Tests
+{
+    public class SpannedWallpaperRendererTests : IDisposable
+    {
+        private readonly string tempDirectory = Path.Combine(Path.GetTempPath(),
+            "WinDynamicDesktop.Tests", Guid.NewGuid().ToString("N"));
+
+        public SpannedWallpaperRendererTests()
+        {
+            Directory.CreateDirectory(tempDirectory);
+        }
+
+        [Fact]
+        public void GetVirtualBoundsHandlesNegativeAndVerticalCoordinates()
+        {
+            List<WallpaperMonitor> monitors =
+            [
+                new WallpaperMonitor { Bounds = Rect(-1920, 0, 0, 1080), ImagePath = "left.jpg" },
+                new WallpaperMonitor { Bounds = Rect(0, -2160, 3840, 0), ImagePath = "top.jpg" }
+            ];
+
+            RECT bounds = SpannedWallpaperRenderer.GetVirtualBounds(monitors);
+
+            Assert.Equal((-1920, -2160, 3840, 1080),
+                (bounds.Left, bounds.Top, bounds.Right, bounds.Bottom));
+        }
+
+        [Fact]
+        public void RenderUsesPhysicalMonitorRectanglesAndPreservesLayoutGaps()
+        {
+            string red = CreateImage("red.png", 1, 1, SKColors.Red);
+            string blue = CreateImage("blue.png", 1, 1, SKColors.Blue);
+            List<WallpaperMonitor> monitors =
+            [
+                new WallpaperMonitor { Bounds = Rect(-2, 0, 0, 2), ImagePath = red },
+                new WallpaperMonitor { Bounds = Rect(1, 0, 4, 2), ImagePath = blue }
+            ];
+
+            using SKBitmap bitmap = SpannedWallpaperRenderer.Render(monitors,
+                DesktopWallpaperPosition.DWPOS_STRETCH, SKColors.Green);
+
+            Assert.Equal((6, 2), (bitmap.Width, bitmap.Height));
+            Assert.Equal(SKColors.Red, bitmap.GetPixel(0, 0));
+            Assert.Equal(SKColors.Green, bitmap.GetPixel(2, 0));
+            Assert.Equal(SKColors.Blue, bitmap.GetPixel(5, 1));
+        }
+
+        [Fact]
+        public void FitKeepsImageAspectRatioWithinEachMonitor()
+        {
+            string imagePath = CreateImage("wide.png", 2, 1, SKColors.Red);
+            List<WallpaperMonitor> monitors =
+            [
+                new WallpaperMonitor { Bounds = Rect(0, 0, 4, 4), ImagePath = imagePath }
+            ];
+
+            using SKBitmap bitmap = SpannedWallpaperRenderer.Render(monitors,
+                DesktopWallpaperPosition.DWPOS_FIT, SKColors.Black);
+
+            Assert.Equal(SKColors.Black, bitmap.GetPixel(0, 0));
+            Assert.Equal(SKColors.Red, bitmap.GetPixel(0, 1));
+        }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(tempDirectory))
+            {
+                Directory.Delete(tempDirectory, true);
+            }
+        }
+
+        private string CreateImage(string filename, int width, int height, SKColor color)
+        {
+            string path = Path.Combine(tempDirectory, filename);
+            using SKBitmap bitmap = new SKBitmap(width, height);
+            bitmap.Erase(color);
+            using SKImage image = SKImage.FromBitmap(bitmap);
+            using SKData data = image.Encode(SKEncodedImageFormat.Png, 100);
+            using FileStream stream = File.Create(path);
+            data.SaveTo(stream);
+            return path;
+        }
+
+        private static RECT Rect(int left, int top, int right, int bottom)
+        {
+            return new RECT { Left = left, Top = top, Right = right, Bottom = bottom };
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- add an opt-in **Sync multi-monitor wallpaper across virtual desktops (experimental)** tray option on Windows 11 22H2+
- compose per-display theme images into one spanned image using the monitor rectangles reported by `IDesktopWallpaper`
- run monitor discovery in a per-monitor-v2 DPI context, so negative coordinates, vertical layouts, mixed resolutions, and scaling are reflected in the output canvas
- assign the composite path to every virtual desktop up front instead of watching desktop switches and reapplying afterward
- restore the user's previous Center/Tile/Stretch/Fit/Fill position and per-monitor wallpapers if the feature is disabled or the virtual desktop API fails

## Why

Windows 11 stores a wallpaper path for each virtual desktop, while WDD's per-display path updates only affect the active desktop. Switching desktops can therefore reveal a stale or single-monitor wallpaper until an external script reapplies the current theme.

This change gives every virtual desktop the same already-composed multi-monitor image. Switching desktops no longer needs a polling script or a delayed refresh, and the existing per-display theme choices remain visually distinct on the physical monitors.

## Implementation notes

- The documented `IDesktopWallpaper` API supplies monitor IDs, screen-coordinate rectangles, background color, and the current wallpaper position.
- `UpdateWallpaperPathForAllDesktops` is an internal Windows interface. Its known Windows 11 22H2/23H2 and 24H2+ vtable layouts are isolated in one file, the option is disabled by default, and all failures are logged and rolled back.
- Unlike the virtual desktop integration removed in v5.1, this does not subscribe to virtual desktop events or add a `VirtualDesktop` package dependency.
- Composite files are content-addressed and cached; only the four most recent files are retained.
- Display changes, resume, and session unlock trigger a layout refresh while the option is enabled.

## Tests

- `dotnet build src/WinDynamicDesktop.csproj --configuration Release`
- `dotnet test test/WinDynamicDesktop.Tests.csproj --configuration Release --filter type!=system` — 10 passed
- single-file self-contained publish succeeded for x86, x64, and ARM64
- renderer tests cover negative coordinates, vertical placement, layout gaps, per-monitor physical rectangles, Stretch, and Fit

The interactive system test was left to CI because it intentionally changes the logged-in user's real wallpaper and first-run configuration.

Closes #694
Related: #321
