### PR TITLE
Fix preview controls not responding on scaled displays

### DIFF
--- a/src/Skia/ThemePreviewer.cs
+++ b/src/Skia/ThemePreviewer.cs
@@ -136,11 +136,11 @@ namespace WinDynamicDesktop.Skia
 
         // The overlay is drawn onto a canvas scaled by uiScale, so DrawOverlay lays its hit regions out in scaled
         // coordinates while mouse events arrive in device pixels. Convert before hit testing, or every region is
-        // offset towards the top left by a factor of uiScale.
+        // offset towards the top left by a factor of uiScale. Reusing the field rather than reading DeviceDpi again
+        // keeps this matched to the scale the current regions were laid out with.
         private Point ToOverlayPoint(Point location)
         {
-            float scale = DeviceDpi / 96f;
-            return new Point((int)(location.X / scale), (int)(location.Y / scale));
+            return new Point((int)(location.X / uiScale), (int)(location.Y / uiScale));
         }
 
         protected override void OnMouseClick(MouseEventArgs e)

--- a/src/Skia/ThemePreviewer.cs
+++ b/src/Skia/ThemePreviewer.cs
@@ -5,6 +5,7 @@
 using SkiaSharp;
 using SkiaSharp.Views.Desktop;
 using System;
+using System.Drawing;
 using System.IO;
 using System.Linq;
 using System.Reflection;
@@ -133,42 +134,53 @@ namespace WinDynamicDesktop.Skia
             }
         }
 
+        // The overlay is drawn onto a canvas scaled by uiScale, so DrawOverlay lays its hit regions out in scaled
+        // coordinates while mouse events arrive in device pixels. Convert before hit testing, or every region is
+        // offset towards the top left by a factor of uiScale.
+        private Point ToOverlayPoint(Point location)
+        {
+            float scale = DeviceDpi / 96f;
+            return new Point((int)(location.X / scale), (int)(location.Y / scale));
+        }
+
         protected override void OnMouseClick(MouseEventArgs e)
         {
             base.OnMouseClick(e);
 
             if (!ViewModel.ControlsVisible) return;
 
+            Point location = ToOverlayPoint(e.Location);
+
             // Check if play button was clicked
-            if (renderer.PlayButtonRect.Contains(e.Location))
+            if (renderer.PlayButtonRect.Contains(location))
             {
                 ViewModel.TogglePlayPause();
                 return;
             }
 
             // Check if left arrow area was clicked
-            if (renderer.LeftArrowRect.Contains(e.Location))
+            if (renderer.LeftArrowRect.Contains(location))
             {
                 ViewModel.Previous();
                 return;
             }
 
             // Check if right arrow area was clicked
-            if (renderer.RightArrowRect.Contains(e.Location))
+            if (renderer.RightArrowRect.Contains(location))
             {
                 ViewModel.Next();
                 return;
             }
 
             // Check if download message was clicked
-            if (renderer.DownloadMessageRect.Contains(e.Location))
+            if (renderer.DownloadMessageRect.Contains(location))
             {
                 ViewModel.InvokeDownload();
                 return;
             }
 
             // Check if carousel indicator was clicked
-            var clickedIndex = Array.FindIndex(renderer.CarouselIndicatorRects ?? [], r => r.Contains(e.Location));
+            var clickedIndex = Array.FindIndex(renderer.CarouselIndicatorRects ?? [], r => r.Contains(location));
             if (clickedIndex != -1)
             {
                 ViewModel.SelectedIndex = clickedIndex;
@@ -188,27 +200,28 @@ namespace WinDynamicDesktop.Skia
 
             var previousHoveredItem = hoveredItem;
             hoveredItem = HoveredItem.None;
+            Point location = ToOverlayPoint(e.Location);
 
             // Check UI elements in priority order
-            if (renderer.PlayButtonRect.Contains(e.Location))
+            if (renderer.PlayButtonRect.Contains(location))
             {
                 hoveredItem = HoveredItem.PlayButton;
             }
-            else if (renderer.DownloadMessageRect.Contains(e.Location))
+            else if (renderer.DownloadMessageRect.Contains(location))
             {
                 hoveredItem = HoveredItem.DownloadButton;
             }
-            else if (renderer.LeftArrowRect.Contains(e.Location))
+            else if (renderer.LeftArrowRect.Contains(location))
             {
                 hoveredItem = HoveredItem.LeftArrow;
             }
-            else if (renderer.RightArrowRect.Contains(e.Location))
+            else if (renderer.RightArrowRect.Contains(location))
             {
                 hoveredItem = HoveredItem.RightArrow;
             }
 
             // Check carousel indicators for hand cursor
-            bool isOverCarouselIndicator = renderer.CarouselIndicatorRects?.Any(r => r.Contains(e.Location)) ?? false;
+            bool isOverCarouselIndicator = renderer.CarouselIndicatorRects?.Any(r => r.Contains(location)) ?? false;
             bool isOverClickable = hoveredItem != HoveredItem.None || isOverCarouselIndicator;
             Cursor = isOverClickable ? Cursors.Hand : Cursors.Default;
 


### PR DESCRIPTION
Fixes #697 

On a display scaled above 100%, the right chevron in the theme preview does nothing, the play/pause button does nothing, and arrow clicks in the lower part of the pane are ignored. Clicking empty image area to the left of the chevron advances the preview instead.

`OnPaintSurface` scales the canvas by `uiScale` and hands `DrawOverlay` an `SKImageInfo` already divided by that factor, so every hit region the renderer stores is in scaled coordinates. `OnMouseClick` and `OnMouseMove` compared them against `e.Location`, which is in device pixels, so at 125% every region sat 20% toward the top left of where it was drawn.

The left chevron kept working only because `LeftArrowRect` starts at `x = 0` and still overlapped where the chevron is drawn — which is why this looks like a right-arrow-only bug.

This converts the mouse position into the same scaled space before hit testing, which fixes the arrows, the play/pause button, the download message and the carousel indicators in one place.

### Note on when this appeared

This is not in 5.7.0 — `v5.7.0:src/Skia/ThemePreviewer.cs` has no `uiScale`, `canvas.Scale` or `logicalInfo`, so the overlay was drawn unscaled and the regions lined up. The scaling came in with 86eccca ("Fix small text in theme preview for high DPI") three weeks after the tag, and the hit testing was not updated alongside it. So this only affects `main`, and would otherwise ship with the next release.

### Testing

- `dotnet test --filter "type!=system"` — 7 passed, unchanged from `main`.
- Manually at 125% scaling: before, the right chevron and play/pause button were dead and clicking ~20% of the pane width to their left triggered them; after, every control responds where it is drawn.
- At 100% scaling behaviour is unchanged, since the conversion is the identity there.