### PR TITLE
Fix hang when theme thumbnail cannot be generated

### DIFF
--- a/src/ThemeDialogUtils.cs
+++ b/src/ThemeDialogUtils.cs
@@ -52,66 +52,82 @@ namespace WinDynamicDesktop
 
         internal static void LoadThemes(List<ThemeConfig> themes, ListView listView, ThemeLoadOpts opts)
         {
-            loadSemaphore.Wait(60000);
-            Size thumbnailSize = ThemeThumbLoader.GetThumbnailSize(listView);
-            ListViewItem focusedItem = null;
+            bool semaphoreAcquired = loadSemaphore.Wait(60000);
 
-            foreach (ThemeConfig theme in themes.ToList())
+            try
             {
-                if (JsonConfig.settings.showInstalledOnly && !ThemeManager.IsThemeDownloaded(theme))
-                {
-                    continue;
-                }
+                Size thumbnailSize = ThemeThumbLoader.GetThumbnailSize(listView);
+                ListViewItem focusedItem = null;
 
-                try
+                foreach (ThemeConfig theme in themes.ToList())
                 {
-                    using (Image thumbnailImage = ThemeThumbLoader.GetThumbnailImage(theme, thumbnailSize, true))
+                    if (JsonConfig.settings.showInstalledOnly && !ThemeManager.IsThemeDownloaded(theme))
                     {
-                        listView.Invoke(new Action(() =>
-                        {
-                            listView.LargeImageList.Images.Add(thumbnailImage);
-                            string itemText = ThemeManager.GetThemeName(theme);
-                            if (JsonConfig.settings.favoriteThemes != null &&
-                                JsonConfig.settings.favoriteThemes.Contains(theme.themeId))
-                            {
-                                itemText = "★ " + itemText;
-                            }
-                            ListViewItem newItem = listView.Items.Add(itemText,
-                                listView.LargeImageList.Images.Count - 1);
-                            newItem.Tag = theme.themeId;
+                        continue;
+                    }
 
-                            if (opts.activeTheme != null && opts.activeTheme == theme.themeId)
+                    try
+                    {
+                        using (Image thumbnailImage = ThemeThumbLoader.GetThumbnailImage(theme, thumbnailSize, true))
+                        {
+                            listView.Invoke(new Action(() =>
                             {
-                                newItem.Font = new Font(newItem.Font, FontStyle.Bold);
-                            }
-                            if (opts.focusTheme == null || opts.focusTheme == theme.themeId)
-                            {
-                                focusedItem = newItem;
-                            }
-                        }));
+                                listView.LargeImageList.Images.Add(thumbnailImage);
+                                string itemText = ThemeManager.GetThemeName(theme);
+                                if (JsonConfig.settings.favoriteThemes != null &&
+                                    JsonConfig.settings.favoriteThemes.Contains(theme.themeId))
+                                {
+                                    itemText = "★ " + itemText;
+                                }
+                                ListViewItem newItem = listView.Items.Add(itemText,
+                                    listView.LargeImageList.Images.Count - 1);
+                                newItem.Tag = theme.themeId;
+
+                                if (opts.activeTheme != null && opts.activeTheme == theme.themeId)
+                                {
+                                    newItem.Font = new Font(newItem.Font, FontStyle.Bold);
+                                }
+                                if (opts.focusTheme == null || opts.focusTheme == theme.themeId)
+                                {
+                                    focusedItem = newItem;
+                                }
+                            }));
+                        }
+                    }
+                    catch (Exception exc)
+                    {
+                        // Image formats that cannot be decoded throw ArgumentException or ExternalException, so
+                        // catching only OutOfMemoryException here used to let the exception escape and leave the
+                        // import dialog waiting for thumbnails forever
+                        LoggingHandler.LogMessage("Failed to generate thumbnail for '{0}' theme: {1}", theme.themeId,
+                            exc);
+                        listView.Invoke(new Action(() =>
+                            ThemeLoader.HandleError(new FailedToCreateThumbnail(theme.themeId))));
                     }
                 }
-                catch (OutOfMemoryException)
+
+                listView.Invoke(new Action(() =>
                 {
-                    ThemeLoader.HandleError(new FailedToCreateThumbnail(theme.themeId));
+                    listView.Sort();
+
+                    if (focusedItem == null)
+                    {
+                        focusedItem = listView.Items[0];
+                    }
+
+                    focusedItem.Selected = true;
+                    listView.EnsureVisible(focusedItem.Index);
+
+                    ThemeThumbLoader.CacheThumbnails(listView);
+                }));
+            }
+            finally
+            {
+                if (semaphoreAcquired)
+                {
+                    loadSemaphore.Release();
                 }
             }
-
-            listView.Invoke(new Action(() =>
-            {
-                listView.Sort();
-
-                if (focusedItem == null)
-                {
-                    focusedItem = listView.Items[0];
-                }
-
-                focusedItem.Selected = true;
-                listView.EnsureVisible(focusedItem.Index);
-
-                ThemeThumbLoader.CacheThumbnails(listView);
-            }));
-            loadSemaphore.Release();
         }
 
         internal static void LoadImportedThemes(List<ThemeConfig> themes, ListView listView, ImportDialog importDialog)
@@ -133,13 +149,24 @@ namespace WinDynamicDesktop
 
             Task.Run(() =>
             {
-                LoadThemes(themes, listView, new ThemeLoadOpts());
-
-                importDialog.Invoke(new Action(() =>
+                try
                 {
-                    importDialog.thumbnailsLoaded = true;
-                    importDialog.Close();
-                }));
+                    LoadThemes(themes, listView, new ThemeLoadOpts());
+                }
+                catch (Exception exc)
+                {
+                    LoggingHandler.LogMessage("Failed to load imported themes: {0}", exc);
+                }
+                finally
+                {
+                    // Closing the dialog here rather than after LoadThemes ensures the import always finishes, even
+                    // if generating thumbnails failed
+                    importDialog.Invoke(new Action(() =>
+                    {
+                        importDialog.thumbnailsLoaded = true;
+                        importDialog.Close();
+                    }));
+                }
             });
         }
 


### PR DESCRIPTION
Fixes #696 

Importing a theme whose images GDI+ cannot decode leaves the import dialog stuck on "Generating thumbnails, please wait..." forever, with no error and nothing in the log. `.webp` is the easy way to hit it, but a truncated JPEG does the same thing.

`GetThumbnailImage` decodes with `System.Drawing`, which throws `ExternalException` (or `ArgumentException`) for a format it cannot read. `LoadThemes` only caught `OutOfMemoryException`, so the exception escaped the loop and faulted the background task started by `LoadImportedThemes` — which closes the dialog on the line after `LoadThemes` returns, so `thumbnailsLoaded` was never set and `OnImportDialogClosing` kept cancelling the close.

Three changes, all in `ThemeDialogUtils`:

- Catch every exception per theme instead of just `OutOfMemoryException`, and log it with the theme id, so the underlying exception ends up in `debug.log` when debug logging is on. The existing `FailedToCreateThumbnail` dialog still shows, now marshalled onto the UI thread rather than raised from the background task.
- Release `loadSemaphore` from a `finally`, and only when the wait actually acquired it. Previously the release was the last statement of the method, so an escaping exception stranded the semaphore and the next load blocked for the full 60s.
- Close the import dialog from a `finally` in `LoadImportedThemes`, so the import completes even when generating thumbnails throws. This is the part that actually ends the hang.

This deliberately does not change which formats are supported — an undecodable image still fails, it just fails visibly and lets the app carry on. Adding WebP support is #690, and a separate PR.

Most of the diff is re-indentation from the new `try` block; `?w=1` shows the real change.

### Testing

- `dotnet test --filter "type!=system"` — 7 passed, unchanged from `main`.
- Manually, importing a `.ddw` whose images are `.webp`: on `main` the import dialog hangs indefinitely and the app has to be killed; with this change the import completes, the theme is reported as "Failed to generate thumbnail: The image could not be loaded", and the app stays usable.
- Importing a normal `.jpg` theme behaves as before.