### PR TITLE
Decode theme thumbnails with SkiaSharp so WebP themes work

### DIFF
--- a/src/ThemeThumbLoader.cs
+++ b/src/ThemeThumbLoader.cs
@@ -9,7 +9,9 @@ using System.Drawing.Imaging;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using System.Runtime.InteropServices;
 using System.Threading.Tasks;
+using SkiaSharp;
 
 namespace WinDynamicDesktop
 {
@@ -52,30 +54,75 @@ namespace WinDynamicDesktop
             return wallpaperPath ?? CreateBlankWallpaper();
         }
 
-        public static Image ScaleImage(Image tempImage, Size size)
+        public static Image ScaleImage(string filename, Size size)
         {
-            if (tempImage.Size == size)
+            using (Stream stream = File.OpenRead(filename))
             {
-                return tempImage;
-            }
-
-            // Image scaling code from https://stackoverflow.com/a/7677163/5504760
-            using (tempImage)
-            {
-                Bitmap bmp = new Bitmap(size.Width, size.Height, PixelFormat.Format32bppArgb);
-
-                using (Graphics g = Graphics.FromImage(bmp))
-                {
-                    g.DrawImage(tempImage, new Rectangle(0, 0, bmp.Width, bmp.Height));
-                }
-
-                return bmp;
+                return ScaleImage(stream, size);
             }
         }
 
-        public static Image ScaleImage(string filename, Size size)
+        // Images are decoded with SkiaSharp rather than System.Drawing so that formats GDI+ cannot read, such as
+        // WebP, are supported here as well as in the theme preview
+        private static Image ScaleImage(Stream stream, Size size)
         {
-            return ScaleImage(Image.FromFile(filename), size);
+            using (SKCodec codec = SKCodec.Create(stream))
+            {
+                if (codec == null)
+                {
+                    throw new ArgumentException("Image could not be decoded because its format is not supported");
+                }
+
+                SKImageInfo info = new SKImageInfo(codec.Info.Width, codec.Info.Height, SKColorType.Bgra8888,
+                    SKAlphaType.Premul);
+
+                using (SKBitmap sourceBitmap = new SKBitmap(info))
+                {
+                    SKCodecResult result = codec.GetPixels(info, sourceBitmap.GetPixels());
+
+                    // Truncated files still decode into a usable image, so only a hard failure is treated as an error
+                    if (result != SKCodecResult.Success && result != SKCodecResult.IncompleteInput)
+                    {
+                        throw new ArgumentException("Image could not be decoded, result was " + result);
+                    }
+
+                    if (sourceBitmap.Width == size.Width && sourceBitmap.Height == size.Height)
+                    {
+                        return ToBitmap(sourceBitmap);
+                    }
+
+                    using (SKBitmap scaledBitmap = new SKBitmap(info.WithSize(size.Width, size.Height)))
+                    {
+                        sourceBitmap.ScalePixels(scaledBitmap, new SKSamplingOptions(SKCubicResampler.Mitchell));
+                        return ToBitmap(scaledBitmap);
+                    }
+                }
+            }
+        }
+
+        private static Bitmap ToBitmap(SKBitmap skBitmap)
+        {
+            Bitmap bmp = new Bitmap(skBitmap.Width, skBitmap.Height, PixelFormat.Format32bppPArgb);
+            BitmapData bmpData = bmp.LockBits(new Rectangle(0, 0, bmp.Width, bmp.Height), ImageLockMode.WriteOnly,
+                bmp.PixelFormat);
+
+            try
+            {
+                byte[] pixels = skBitmap.Bytes;
+                int rowBytes = Math.Min(skBitmap.RowBytes, bmpData.Stride);
+
+                for (int y = 0; y < skBitmap.Height; y++)
+                {
+                    Marshal.Copy(pixels, y * skBitmap.RowBytes, IntPtr.Add(bmpData.Scan0, y * bmpData.Stride),
+                        rowBytes);
+                }
+            }
+            finally
+            {
+                bmp.UnlockBits(bmpData);
+            }
+
+            return bmp;
         }
 
         public static Image GetThumbnailImage(ThemeConfig theme, Size size, bool useCache)
@@ -102,7 +149,7 @@ namespace WinDynamicDesktop
 
                     using (Stream stream = Assembly.GetExecutingAssembly().GetManifestResourceStream(resourceName))
                     {
-                        return ScaleImage(Image.FromStream(stream), size);
+                        return ScaleImage(stream, size);
                     }
                 }
             }

--- a/src/ThemeThumbLoader.cs
+++ b/src/ThemeThumbLoader.cs
@@ -130,27 +130,31 @@ namespace WinDynamicDesktop
             if (useCache)
             {
                 string thumbnailPath = GetThumbnailPath(theme);
-                if (File.Exists(thumbnailPath))
-                {
-                    Image cachedImage = Image.FromFile(thumbnailPath);
 
-                    if (cachedImage.Size == size)
+                try
+                {
+                    if (File.Exists(thumbnailPath))
                     {
-                        return cachedImage;
+                        // Scaling instead of discarding a thumbnail whose size does not match keeps a thumbnail
+                        // supplied with the theme, and avoids regenerating cached ones whenever the display DPI
+                        // makes the requested size something other than 192x108
+                        return ScaleImage(thumbnailPath, size);
                     }
-                    else
+                    else if (ThemeManager.defaultThemes.Contains(theme.themeId))
                     {
-                        cachedImage.Dispose();
+                        string resourceName = "WinDynamicDesktop.resources.images." + theme.themeId +
+                            "_thumbnail.jpg";
+
+                        using (Stream stream = Assembly.GetExecutingAssembly().GetManifestResourceStream(resourceName))
+                        {
+                            return ScaleImage(stream, size);
+                        }
                     }
                 }
-                else if (ThemeManager.defaultThemes.Contains(theme.themeId))
+                catch (Exception exc)
                 {
-                    string resourceName = "WinDynamicDesktop.resources.images." + theme.themeId + "_thumbnail.jpg";
-
-                    using (Stream stream = Assembly.GetExecutingAssembly().GetManifestResourceStream(resourceName))
-                    {
-                        return ScaleImage(stream, size);
-                    }
+                    LoggingHandler.LogMessage("Failed to load cached thumbnail for '{0}' theme, generating a new " +
+                        "one: {1}", theme.themeId, exc);
                 }
             }
 


### PR DESCRIPTION
Relates to #690 , and to #696 .

In #690 you mentioned WDD should already handle previewing `.png` and `.webp`. Preview does — `Skia/ImageCache.cs` decodes through `SKCodec`, which reads WebP fine. Thumbnail generation was missed by the 5.7.0 Skia change though: `ThemeThumbLoader` still decodes with `System.Drawing`, and GDI+ cannot read WebP at all. `Image.FromFile` on a `.webp` throws:

```
System.Runtime.InteropServices.ExternalException: An object could not be created, possibly due to
a lack of memory, but most likely due to invalid input.
```

So a WebP theme previews but has no thumbnail — and before #NNN is fixed, that exception hangs the import dialog outright.

### What this changes

**Decode thumbnails with `SKCodec`** (first commit). Same decoder and the same `SKCubicResampler.Mitchell` sampling the preview renderer already uses, then a pixel copy into a `Bitmap` for the `ListView` image list. `ScaleImage(Image, Size)` is gone since every caller now starts from a path or a stream. No new package — `SkiaSharp` is already referenced.

**Reuse cached thumbnails that do not match the requested size** (second commit). `GetThumbnailImage` only reused a cached thumbnail when its size matched exactly, and otherwise disposed it and regenerated from the theme images. That meant a `thumbnail.png` supplied with a theme was silently ignored unless it happened to be exactly 192x108, and on any display not at 100% scaling — where the requested size is e.g. 256x144 — even the bundled thumbnails were discarded and regenerated on every single load. It now scales the cached thumbnail, and falls back to generating a new one if the file cannot be read.

I did not re-save the scaled result to `thumbnail.png`, so a thumbnail shipped with a theme stays as the author made it rather than being overwritten by the cache. Happy to change that if you would rather the cache always hold the display-sized version.

### Testing

- `dotnet test --filter "type!=system"` — 7 passed, unchanged from `main`.
- Decoder checked directly against 1920x1080 `.jpg`, `.png` and `.webp` files, scaling to 192x108 and upscaling 192x108 to 256x144. Verified the output is the requested size and that four known-colour quadrants land in the right place with the right values, which catches both channel-order and orientation mistakes. `.webp` fails on `main` with the exception above and passes here; `.jpg` and `.png` pass on both.
- Manually: a WebP theme that hangs the import on `main` now imports with a real generated thumbnail and previews correctly.

### Note on scope

This is only about WDD reading WebP theme images. It does not touch how wallpaper is handed to Windows, so it is not the whole of #690 if that also means writing `.webp` to the desktop on builds that support it natively — happy to leave that part alone or look at it separately.